### PR TITLE
Support for allowing the thumb to rest at the bottom of the trackpad

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ The minimum size of what's considered a palm. Palms are expected to be very
 large on the trackpad. This is represented as a percentage of the maximum touch
 value and is dependent on the trackpad hardware. Integer value. Defaults to 40.
 
+**BottomEdge** -
+The size of an area at the bottom of the trackpad where new touches are ignored
+(fingers traveling into this area from above will still be tracked). This is
+represented as a percentage of the total trackpad height. Defaults to 10.
+
 **ButtonEnable** - 
 Whether or not to enable the physical buttons on or near the trackpad. Boolean
 value. Defaults to true.

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -34,6 +34,7 @@
 #define DEFAULT_THUMB_RATIO 70
 #define DEFAULT_THUMB_SIZE 25
 #define DEFAULT_PALM_SIZE 40
+#define DEFAULT_BOTTOM_EDGE 10
 #define DEFAULT_BUTTON_ENABLE 1
 #define DEFAULT_BUTTON_INTEGRATED 1
 #define DEFAULT_BUTTON_ZONES 0
@@ -103,6 +104,7 @@ struct MConfig {
 	int thumb_ratio;	// Ratio of width to length that makes a touch a thumb. 0 - 100
 	int thumb_size;		// Minimum touch size for a thumb. 0 - 100
 	int palm_size;		// Minimum touch size for a palm. 0 - 100
+	int bottom_edge;		// Percent of bottom of trackpad to ignore for new touches. 0 - 100
 
 	/* Used by Gestures */
 

--- a/include/mtstate.h
+++ b/include/mtstate.h
@@ -32,6 +32,7 @@
 #define MT_INVALID 2
 #define MT_THUMB 3
 #define MT_PALM 4
+#define MT_BOTTOM_EDGE 5
 
 struct Touch {
 	bitmask_t state;

--- a/src/mconfig.c
+++ b/src/mconfig.c
@@ -33,6 +33,7 @@ void mconfig_defaults(struct MConfig* cfg)
 	cfg->thumb_ratio = DEFAULT_THUMB_RATIO;
 	cfg->thumb_size = DEFAULT_THUMB_SIZE;
 	cfg->palm_size = DEFAULT_PALM_SIZE;
+	cfg->bottom_edge = DEFAULT_BOTTOM_EDGE;
 
 	// Configure Gestures
 	cfg->trackpad_disable = DEFAULT_TRACKPAD_DISABLE;
@@ -84,7 +85,7 @@ void mconfig_init(struct MConfig* cfg,
 	cfg->touch_minor = caps->has_abs[MTDEV_TOUCH_MINOR];
 	cfg->pad_width = get_cap_xsize(caps);
 	cfg->pad_height = get_cap_ysize(caps);
-
+	
 	if (caps->has_abs[MTDEV_TOUCH_MAJOR] && caps->has_abs[MTDEV_WIDTH_MAJOR]) {
 		cfg->touch_type = MCFG_SCALE;
 		cfg->touch_min = caps->abs[MTDEV_TOUCH_MAJOR].minimum;
@@ -128,6 +129,7 @@ void mconfig_configure(struct MConfig* cfg,
 	cfg->thumb_ratio = CLAMPVAL(xf86SetIntOption(opts, "ThumbRatio", DEFAULT_THUMB_RATIO), 0, 100);
 	cfg->thumb_size = CLAMPVAL(xf86SetIntOption(opts, "ThumbSize", DEFAULT_THUMB_SIZE), 0, 100);
 	cfg->palm_size = CLAMPVAL(xf86SetIntOption(opts, "PalmSize", DEFAULT_PALM_SIZE), 0, 100);
+	cfg->bottom_edge = CLAMPVAL(xf86SetIntOption(opts, "BottomEdge", DEFAULT_BOTTOM_EDGE), 0, 100);
 
 	// Configure Gestures
 	cfg->trackpad_disable = CLAMPVAL(xf86SetIntOption(opts, "TrackpadDisable", DEFAULT_TRACKPAD_DISABLE), 0, 3);


### PR DESCRIPTION
Adds support for a "BottomEdge" option specifying a zone where new touches aren't tracked. Touches traveling into the zone from above are tracked.

Furthermore, allows touches classified as thumbs or palms to lose this classification without lifting the finger off the trackpad.
