### PR TITLE
Touchscreen support

### DIFF
--- a/driver/mtrack.c
+++ b/driver/mtrack.c
@@ -193,8 +193,15 @@ static int device_close(LocalDevicePtr local)
 static void handle_gestures(LocalDevicePtr local,
 			const struct Gestures* gs)
 {
+	const struct MTouch *mt = local->private;
 	static bitmask_t buttons_prev = 0U;
 	int i;
+
+	/* Give the HW coordinates to Xserver as absolute coordinates, these coordinates
+	 * are not scaled, this is oke if the touchscreen has the same resolution as the display.
+	 */
+	if(mt->cfg.absolute_mode == TRUE)
+		xf86PostMotionEvent(local->dev, 1, 0, 2, mt->state.touch[0].x, mt->state.touch[0].y);
 
 	for (i = 0; i < 32; i++) {
 		if (GETBIT(gs->buttons, i) == GETBIT(buttons_prev, i))
@@ -214,7 +221,7 @@ static void handle_gestures(LocalDevicePtr local,
 	}
 	buttons_prev = gs->buttons;
 
-	if (gs->move_dx != 0 || gs->move_dy != 0)
+	if (mt->cfg.absolute_mode == FALSE && (gs->move_dx != 0 || gs->move_dy != 0))
 		xf86PostMotionEvent(local->dev, 0, 0, 2, gs->move_dx, gs->move_dy);
 }
 
@@ -227,6 +234,28 @@ static void read_input(LocalDevicePtr local)
 	if (mtouch_delayed(mt))
 		handle_gestures(local, &mt->gs);
 }
+
+static int switch_mode(ClientPtr client, DeviceIntPtr dev, int mode)
+{
+	LocalDevicePtr local = dev->public.devicePrivate;
+	struct MTouch *mt = local->private;
+
+	switch (mode) {
+	case Absolute:
+		mt->cfg.absolute_mode = TRUE;
+		xf86Msg(X_INFO, "Switing to absolute mode\n");
+		break;
+	case Relative:
+		mt->cfg.absolute_mode = FALSE;
+		xf86Msg(X_INFO, "Switing to relative mode\n");
+		break;
+	default:
+		return XI_BadMode;
+	}
+
+	return Success;
+}
+
 
 static Bool device_control(DeviceIntPtr dev, int mode)
 {
@@ -264,7 +293,7 @@ static int preinit(InputDriverPtr drv, InputInfoPtr pInfo, int flags)
 	pInfo->type_name = XI_TOUCHPAD;
 	pInfo->device_control = device_control;
 	pInfo->read_input = read_input;
-	pInfo->switch_mode = 0;
+	pInfo->switch_mode = switch_mode;
 
     xf86CollectInputOptions(pInfo, NULL);
     xf86OptionListReport(pInfo->options);
@@ -288,6 +317,7 @@ static InputInfoPtr preinit(InputDriverPtr drv, IDevPtr dev, int flags)
 	local->type_name = XI_TOUCHPAD;
 	local->device_control = device_control;
 	local->read_input = read_input;
+	local->switch_mode = switch_mode;
 	local->private = mt;
 	local->flags = XI86_POINTER_CAPABLE | XI86_SEND_DRAG_EVENTS;
 	local->conf_idev = dev;

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -162,6 +162,7 @@ struct MConfig {
 	int drag_wait;			// How long to wait before triggering button down? >= 0
 	int drag_dist;			// How far is the finger allowed to move during wait time? >= 0
 	double sensitivity;		// Mouse movement multiplier. >= 0
+	int absolute_mode;		// Should absolute mode be enabled ? 0 or 1
 };
 
 /* Load the MConfig struct with its defaults.


### PR DESCRIPTION
Add support for the absolute coordinates mode. This is needed to support 
multitouch touchscreens, instead of touchpad's where this driver was intended 
for. This is working perfectly on my sabreLite iMX6 board with a Nit6X 
multitouch touchscreen. All the multitouch events are still working properly. 
Remark: There is no scaling on the absolute input coordinates so both 
resolutions should match.

I modified this driver for multitouch touchscreen, because I couldn't find another xserver driver for multitouch touchscreens. Because I know that this driver does support all the needed gestures that we want to support in our products.

I'm sending this patch because I think that also others can benefit from it. And other people has the same problems with finding a good multitouch touchscreen driver.

I also implemented you're remarks as best as possible.

If you still have any questions or what so ever, please contact me.

Best regards,

Jasper Nevens
