### PR TITLE
Add high precision scrolling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ This value is the amount of time you must be performing the new gesture before
 it is triggered. This prevents accidental touches from triggering other
 gestures. Integer value representing milliseconds. Defaults to 100.
 
-**ScrollDistance** -
+**ScrollHighPrecision** -
 For two finger scrolling. Whether to generate high precision scroll events.
 Boolean value. Defaults to 1.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ This value is the amount of time you must be performing the new gesture before
 it is triggered. This prevents accidental touches from triggering other
 gestures. Integer value representing milliseconds. Defaults to 100.
 
+**ScrollDistance** -
+For two finger scrolling. Whether to generate high precision scroll events.
+Boolean value. Defaults to 1.
+
 **ScrollDistance** - 
 For two finger scrolling. How far you must move your fingers before a button
 click is triggered. Integer value. Defaults to 150.

--- a/driver/mprops.c
+++ b/driver/mprops.c
@@ -439,7 +439,7 @@ int mprops_set_property(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop
 			return BadMatch;
 
 		if (!checkonly) {
-			cfg->scroll_high_prec = ivals32[0];
+			cfg->scroll_high_prec = ivals8[0];
 #ifdef DEBUG_PROPS
 			xf86Msg(X_INFO, "mtrack: set high precision scrolling to %d\n",
 				cfg->scroll_high_prec);

--- a/driver/mprops.c
+++ b/driver/mprops.c
@@ -142,6 +142,9 @@ void mprops_init(struct MConfig* cfg, InputInfoPtr local) {
 	ivals[1] = cfg->gesture_wait;
 	mprops.gesture_settings = atom_init_integer(local->dev, MTRACK_PROP_GESTURE_SETTINGS, 2, ivals, 16);
 
+	ivals[0] = cfg->scroll_high_prec;
+	mprops.scroll_high_prec = atom_init_integer(local->dev, MTRACK_PROP_SCROLL_HIGH_PRECISION, 1, ivals, 8);
+
 	ivals[0] = cfg->scroll_dist;
 	mprops.scroll_dist = atom_init_integer(local->dev, MTRACK_PROP_SCROLL_DIST, 1, ivals, 32);
 
@@ -424,6 +427,22 @@ int mprops_set_property(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop
 #ifdef DEBUG_PROPS
 			xf86Msg(X_INFO, "mtrack: set gesture settings to %d %d\n",
 				cfg->gesture_hold, cfg->gesture_wait);
+#endif
+		}
+	}
+	else if (property == mprops.scroll_high_prec) {
+		if (prop->size != 1 || prop->format != 8 || prop->type != XA_INTEGER)
+			return BadMatch;
+
+		ivals8 = (uint8_t*)prop->data;
+		if (!VALID_BOOL(ivals8[0]))
+			return BadMatch;
+
+		if (!checkonly) {
+			cfg->scroll_high_prec = ivals32[0];
+#ifdef DEBUG_PROPS
+			xf86Msg(X_INFO, "mtrack: set high precision scrolling to %d\n",
+				cfg->scroll_high_prec);
 #endif
 		}
 	}

--- a/driver/mtrack.c
+++ b/driver/mtrack.c
@@ -57,7 +57,7 @@ static void pointer_control(DeviceIntPtr dev, PtrCtrl *ctrl)
 #if GET_ABI_MAJOR(ABI_XINPUT_VERSION) >= 7
 static void initAxesLabels(Atom map[NUM_AXES])
 {
-	memset(map, 0, 2 * sizeof(Atom));
+	memset(map, 0, NUM_AXES * sizeof(Atom));
 	PROPMAP(map, 0, AXIS_LABEL_PROP_REL_X);
 	PROPMAP(map, 1, AXIS_LABEL_PROP_REL_Y);
 	PROPMAP(map, 2, AXIS_LABEL_PROP_REL_HSCROLL);

--- a/include/gestures.h
+++ b/include/gestures.h
@@ -60,7 +60,7 @@ struct Gestures {
 	int move_dx, move_dy;
 
 	/* Scroll vertical, horizontal.
-	*/
+	 */
 	double move_axes[2];
 
 	/* Current time and time delta. Updated after each event and after sleeping.

--- a/include/gestures.h
+++ b/include/gestures.h
@@ -43,6 +43,10 @@ struct MTouch;
 #define GS_DRAG_WAIT 7
 #define GS_DRAG_ACTIVE 8
 
+#define GS_AXIS_SCROLL_VERTICAL 0
+#define GS_AXIS_SCROLL_HORIZONTAL 1
+#define GS_NUM_AXES 2
+
 struct Gestures {
 	/* Taps, physical buttons, and gestures will trigger
 	 * button events. If a bit is set, the button is down.
@@ -54,6 +58,10 @@ struct Gestures {
 	/* Pointer movement is tracked here.
 	 */
 	int move_dx, move_dy;
+
+	/* Scroll vertical, horizontal.
+	*/
+	double move_axes[2];
 
 	/* Current time and time delta. Updated after each event and after sleeping.
 	 */

--- a/include/gestures.h
+++ b/include/gestures.h
@@ -61,7 +61,7 @@ struct Gestures {
 
 	/* Scroll vertical, horizontal.
 	 */
-	double move_axes[2];
+	double move_axes[GS_NUM_AXES];
 
 	/* Current time and time delta. Updated after each event and after sleeping.
 	 */

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -52,6 +52,7 @@
 #define DEFAULT_TAP_DIST 400
 #define DEFAULT_GESTURE_HOLD 10
 #define DEFAULT_GESTURE_WAIT 100
+#define DEFAULT_SCROLL_HIGH_PREC 1
 #define DEFAULT_SCROLL_DIST 150
 #define DEFAULT_SCROLL_UP_BTN 4
 #define DEFAULT_SCROLL_DN_BTN 5
@@ -136,6 +137,7 @@ struct MConfig {
 	int tap_dist;			// How far to allow a touch to move before it's a moving touch. > 0
 	int gesture_hold;		// How long to "hold down" the emulated button for gestures. > 0
 	int gesture_wait;		// How long after a gesture to wait before movement is allowed. >= 0
+	int scroll_high_prec;		// Enable high precision scrolling. 0 or 1.
 	int scroll_dist;		// Distance needed to trigger a button. >= 0, 0 disables
 	int scroll_up_btn;		// Button to use for scroll up. >= 0, 0 is none
 	int scroll_dn_btn;		// Button to use for scroll down. >= 0, 0 is none

--- a/include/mprops.h
+++ b/include/mprops.h
@@ -62,9 +62,9 @@
 #define MTRACK_PROP_PALM_SIZE "Trackpad Palm Size"
 // int, 2 value - button hold, wait time
 #define MTRACK_PROP_GESTURE_SETTINGS "Trackpad Gesture Settings"
-// int, 1 value - distance before a scroll event is triggered
-#define MTRACK_PROP_SCROLL_HIGH_PRECISION "Trackpad High Precision Scrolling"
 // int, 1 value - enable high precision scrolling
+#define MTRACK_PROP_SCROLL_HIGH_PRECISION "Trackpad High Precision Scrolling"
+// int, 1 value - distance before a scroll event is triggered
 #define MTRACK_PROP_SCROLL_DIST "Trackpad Scroll Distance"
 // int, 4 values - up button, down button, left button, right button
 #define MTRACK_PROP_SCROLL_BUTTONS "Trackpad Scroll Buttons"

--- a/include/mprops.h
+++ b/include/mprops.h
@@ -63,6 +63,8 @@
 // int, 2 value - button hold, wait time
 #define MTRACK_PROP_GESTURE_SETTINGS "Trackpad Gesture Settings"
 // int, 1 value - distance before a scroll event is triggered
+#define MTRACK_PROP_SCROLL_HIGH_PRECISION "Trackpad High Precision Scrolling"
+// int, 1 value - enable high precision scrolling
 #define MTRACK_PROP_SCROLL_DIST "Trackpad Scroll Distance"
 // int, 4 values - up button, down button, left button, right button
 #define MTRACK_PROP_SCROLL_BUTTONS "Trackpad Scroll Buttons"
@@ -106,6 +108,7 @@ struct MProps {
 	Atom palm_detect;
 	Atom palm_size;
 	Atom gesture_settings;
+	Atom scroll_high_prec;
 	Atom scroll_dist;
 	Atom scroll_buttons;
 	Atom swipe_dist;

--- a/include/mtouch.h
+++ b/include/mtouch.h
@@ -38,6 +38,7 @@ struct MTouch {
 	struct MTState state;
 	struct MConfig cfg;
 	struct Gestures gs;
+	ValuatorMask* vm;
 };
 
 int mtouch_configure(struct MTouch* mt, int fd);

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -388,7 +388,7 @@ static void clear_move(struct Gestures* gs)
 	gs->move_dy = 0;
 	int i;
 	for (i = 0; i < GS_NUM_AXES; ++i)
-			gs->move_axes[i] = 0;
+		gs->move_axes[i] = 0;
 }
 
 static void trigger_move(struct Gestures* gs,
@@ -435,7 +435,7 @@ static void trigger_scroll(struct Gestures* gs,
 		if (cfg->scroll_high_prec)
 		{
 			if ((distx == 0.0) && (disty == 0.0))
-					return;
+				return;
 
 			gs->move_axes[GS_AXIS_SCROLL_HORIZONTAL] = distx;
 			gs->move_axes[GS_AXIS_SCROLL_VERTICAL] = disty;

--- a/src/mconfig.c
+++ b/src/mconfig.c
@@ -53,6 +53,7 @@ void mconfig_defaults(struct MConfig* cfg)
 	cfg->tap_dist = DEFAULT_TAP_DIST;
 	cfg->gesture_hold = DEFAULT_GESTURE_HOLD;
 	cfg->gesture_wait = DEFAULT_GESTURE_WAIT;
+	cfg->scroll_high_prec = DEFAULT_SCROLL_HIGH_PREC;
 	cfg->scroll_dist = DEFAULT_SCROLL_DIST;
 	cfg->scroll_up_btn = DEFAULT_SCROLL_UP_BTN;
 	cfg->scroll_dn_btn = DEFAULT_SCROLL_DN_BTN;
@@ -150,6 +151,7 @@ void mconfig_configure(struct MConfig* cfg,
 	cfg->tap_dist = MAXVAL(xf86SetIntOption(opts, "MaxTapMove", DEFAULT_TAP_DIST), 1);
 	cfg->gesture_hold = MAXVAL(xf86SetIntOption(opts, "GestureClickTime", DEFAULT_GESTURE_HOLD), 1);
 	cfg->gesture_wait = MAXVAL(xf86SetIntOption(opts, "GestureWaitTime", DEFAULT_GESTURE_WAIT), 0);
+	cfg->scroll_high_prec = CLAMPVAL(xf86SetIntOption(opts, "ScrollHighPrecision", DEFAULT_SCROLL_HIGH_PREC), 0, 1);
 	cfg->scroll_dist = MAXVAL(xf86SetIntOption(opts, "ScrollDistance", DEFAULT_SCROLL_DIST), 1);
 	cfg->scroll_up_btn = CLAMPVAL(xf86SetIntOption(opts, "ScrollUpButton", DEFAULT_SCROLL_UP_BTN), 0, 32);
 	cfg->scroll_dn_btn = CLAMPVAL(xf86SetIntOption(opts, "ScrollDownButton", DEFAULT_SCROLL_DN_BTN), 0, 32);


### PR DESCRIPTION
Adds high precision scroll events -- informing Xorg of scrolling via motion events with distance values rather than through button click events.

Added a configuration option (and entry to README.md) to turn it on/off - ScrollHighPrecision.

In this patch set, that option defaults to _on_.

Tested in a variety of Qt apps + firefox-gtk3.
