### PR TITLE
Bottom edge button zones feature (to emulate traditional trackpad)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,15 @@ those ClickFinger values that are enabled. So setting ClickFinger1 to 0 and
 enabling the other two will create two zones, one for ClickFinger2 and one for
 ClickFinger3. Boolean value. Defaults to false.
 
+**BottomEdgeZonesEnable** -
+Whether to enable button zones in the bottom edge.  If this feature is
+enabled then touches in the BottomEdge region determine which button
+is sent.  The vertical division of the zones is as for
+ButtonZonesEnable.  If there is no touch in the bottom edge, then
+button 0 will be sent (or the button according to ButtonZonesEnable,
+if that is enabled).  This is particularly useful for clickpads with
+integrated buttons. Defaults to false.
+
 **ButtonTouchExpire** - 
 How long (in ms) to consider a touching finger as part of button emulation. A
 value of 0 will not expire touches. Integer value. Defaults to 100.

--- a/driver/mprops.c
+++ b/driver/mprops.c
@@ -105,7 +105,8 @@ void mprops_init(struct MConfig* cfg, InputInfoPtr local) {
 	ivals[0] = cfg->button_zones;
 	ivals[1] = cfg->button_move;
 	ivals[2] = cfg->button_expire;
-	mprops.button_emulate_settings = atom_init_integer(local->dev, MTRACK_PROP_BUTTON_EMULATE_SETTINGS, 3, ivals, 16);
+	ivals[3] = cfg->bottom_edge_zones;
+	mprops.button_emulate_settings = atom_init_integer(local->dev, MTRACK_PROP_BUTTON_EMULATE_SETTINGS, 4, ivals, 16);
 
 	ivals[0] = cfg->button_1touch;
 	ivals[1] = cfg->button_2touch;
@@ -271,20 +272,27 @@ int mprops_set_property(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop
 		}
 	}
 	else if (property == mprops.button_emulate_settings) {
-		if (prop->size != 3 || prop->format != 16 || prop->type != XA_INTEGER)
+		if (prop->size < 3 || prop->size > 4 || prop->format != 16 || prop->type != XA_INTEGER)
 			return BadMatch;
 
 		ivals16 = (uint16_t*)prop->data;
 		if (!VALID_BOOL(ivals16[0]) || !VALID_BOOL(ivals16[1]) || ivals16[2] < 0)
 			return BadMatch;
 
+		if (prop->size >= 4) {
+			if (!VALID_BOOL(ivals16[3]))
+				return BadMatch;
+		}
+
 		if (!checkonly) {
 			cfg->button_zones = ivals16[0];
 			cfg->button_move = ivals16[1];
 			cfg->button_expire = ivals16[2];
+			if (prop->size >= 4)
+				cfg->bottom_edge_zones = ivals16[3];
 #ifdef DEBUG_PROPS
-			xf86Msg(X_INFO, "mtrack: set button emulate settings to %d %d %d\n",
-				cfg->button_zones, cfg->button_move, cfg->button_expire);
+			xf86Msg(X_INFO, "mtrack: set button emulate settings to %d %d %d %d\n",
+				cfg->button_zones, cfg->button_move, cfg->button_expire, cfg->bottom_edge_zones);
 #endif
 		}
 	}

--- a/include/capabilities.h
+++ b/include/capabilities.h
@@ -44,6 +44,9 @@ int get_cap_wsize(const struct Capabilities *cap);
 int get_cap_xmid(const struct Capabilities *cap);
 int get_cap_ymid(const struct Capabilities *cap);
 
+int get_cap_xmin(const struct Capabilities *cap);
+int get_cap_ymin(const struct Capabilities *cap);
+
 int get_cap_xflip(const struct Capabilities *cap, int x);
 int get_cap_yflip(const struct Capabilities *cap, int y);
 

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -96,6 +96,8 @@ struct MConfig {
 	int touch_max;		// Maximum touch value.
 	int pad_width;		// Width of the touchpad.
 	int pad_height;		// Height of the touchpad.
+	int pad_xmin;		// Minimum x coordinate.
+	int pad_ymin;		// Minimum y coordinate.
 
 	// Set by config.
 	int touch_down;		// When is a finger touching? 0 - 100 (percentage)

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -38,6 +38,7 @@
 #define DEFAULT_BUTTON_ENABLE 1
 #define DEFAULT_BUTTON_INTEGRATED 1
 #define DEFAULT_BUTTON_ZONES 0
+#define DEFAULT_BOTTOM_EDGE_ZONES 0
 #define DEFAULT_BUTTON_1TOUCH 3
 #define DEFAULT_BUTTON_2TOUCH 2
 #define DEFAULT_BUTTON_3TOUCH 0
@@ -121,6 +122,7 @@ struct MConfig {
 	int button_integrated;	// Is the button under the touchpad? 0 or 1
 	int button_expire;		// How long to consider a touch for button emulation. >= 0
 	int button_zones;		// Use button zones for emulation?
+	int bottom_edge_zones;		// Use bottom edge zones for emulation?
 	int button_1touch;		// What button to emulate when one finger is on the
 							// pad or the first zone is clicked? 0 to 32
 	int button_2touch;		// What button to emulate when two fingers are on the

--- a/include/mprops.h
+++ b/include/mprops.h
@@ -44,7 +44,7 @@
 #define MTRACK_PROP_PRESSURE "Trackpad Touch Pressure"
 // int, 2 values - enable buttons, has integrated button
 #define MTRACK_PROP_BUTTON_SETTINGS "Trackpad Button Settings"
-// int, 3 values - enable button zones, button move emulation, emulation touch expiration
+// int, 3-4 values - enable button zones, button move emulation, emulation touch expiration[, enable bottom edge zones]
 #define MTRACK_PROP_BUTTON_EMULATE_SETTINGS "Trackpad Button Emulation Settings"
 // int, 3 values - button to emulate with 1 touch, 2 touches, 3 touches
 #define MTRACK_PROP_BUTTON_EMULATE_VALUES "Trackpad Button Emulation Values"

--- a/src/capabilities.c
+++ b/src/capabilities.c
@@ -151,6 +151,18 @@ int get_cap_ymid(const struct Capabilities *cap)
 	return (y->maximum + y->minimum) >> 1;
 }
 
+int get_cap_xmin(const struct Capabilities *cap)
+{
+	const struct input_absinfo *x = &cap->abs[MTDEV_POSITION_X];
+	return x->minimum;
+}
+
+int get_cap_ymin(const struct Capabilities *cap)
+{
+	const struct input_absinfo *y = &cap->abs[MTDEV_POSITION_Y];
+	return y->minimum;
+}
+
 int get_cap_xflip(const struct Capabilities *cap, int x)
 {
 	const struct input_absinfo *i = &cap->abs[MTDEV_POSITION_X];

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -210,9 +210,19 @@ static void buttons_update(struct Gestures* gs,
 		}
 
 		if (emulate) {
+			int try_zone;
+			int pos;
+
 			if (cfg->button_zones && earliest >= 0) {
-				int zones, left, right, pos;
+				pos = ms->touch[earliest].x;
+				try_zone = 1;
+			}
+
+			if (try_zone) {
+				int zones, left, right;
 				double width;
+
+				pos -= cfg->pad_xmin;
 
 				zones = 0;
 				if (cfg->button_1touch > 0)
@@ -224,7 +234,6 @@ static void buttons_update(struct Gestures* gs,
 
 				if (zones > 0) {
 					width = ((double)cfg->pad_width)/((double)zones);
-					pos = ms->touch[earliest].x - cfg->pad_xmin;
 #ifdef DEBUG_GESTURES
 					xf86Msg(X_INFO, "buttons_update: pad width %d (min %d), zones %d, zone width %f, x %d\n",
 						cfg->pad_width, cfg->pad_xmin, zones, width, pos);

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -224,10 +224,10 @@ static void buttons_update(struct Gestures* gs,
 
 				if (zones > 0) {
 					width = ((double)cfg->pad_width)/((double)zones);
-					pos = cfg->pad_width / 2 + ms->touch[earliest].x;
+					pos = ms->touch[earliest].x - cfg->pad_xmin;
 #ifdef DEBUG_GESTURES
-					xf86Msg(X_INFO, "buttons_update: pad width %d, zones %d, zone width %f, x %d\n",
-						cfg->pad_width, zones, width, pos);
+					xf86Msg(X_INFO, "buttons_update: pad width %d (min %d), zones %d, zone width %f, x %d\n",
+						cfg->pad_width, cfg->pad_xmin, zones, width, pos);
 #endif
 					for (i = 0; i < zones; i++) {
 						left = width*i;

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -217,6 +217,23 @@ static void buttons_update(struct Gestures* gs,
 				pos = ms->touch[earliest].x;
 				try_zone = 1;
 			}
+			if (cfg->bottom_edge_zones) {
+				int latest_bottom = -1;
+				foreach_bit(i, ms->touch_used) {
+					if (!GETBIT(ms->touch[i].state, MT_BOTTOM_EDGE))
+						continue;
+					if (GETBIT(ms->touch[i].state, MT_PALM) && cfg->ignore_palm)
+						continue;
+					/* we deliberately don't ignore thumbs for bottom button zones */
+
+					if (latest_bottom == -1 || timercmp(&ms->touch[i].down, &ms->touch[latest_bottom].down, >))
+						latest_bottom = i;
+				}
+				if (latest_bottom >= 0) {
+					pos = ms->touch[latest_bottom].x;
+					try_zone = 1;
+				}
+			}
 
 			if (try_zone) {
 				int zones, left, right;

--- a/src/mconfig.c
+++ b/src/mconfig.c
@@ -85,6 +85,8 @@ void mconfig_init(struct MConfig* cfg,
 	cfg->touch_minor = caps->has_abs[MTDEV_TOUCH_MINOR];
 	cfg->pad_width = get_cap_xsize(caps);
 	cfg->pad_height = get_cap_ysize(caps);
+	cfg->pad_xmin = get_cap_xmin(caps);
+	cfg->pad_ymin = get_cap_ymin(caps);
 	
 	if (caps->has_abs[MTDEV_TOUCH_MAJOR] && caps->has_abs[MTDEV_WIDTH_MAJOR]) {
 		cfg->touch_type = MCFG_SCALE;

--- a/src/mconfig.c
+++ b/src/mconfig.c
@@ -41,6 +41,7 @@ void mconfig_defaults(struct MConfig* cfg)
 	cfg->button_integrated = DEFAULT_BUTTON_INTEGRATED;
 	cfg->button_expire = DEFAULT_BUTTON_EXPIRE;
 	cfg->button_zones = DEFAULT_BUTTON_ZONES;
+	cfg->bottom_edge_zones = DEFAULT_BOTTOM_EDGE_ZONES;
 	cfg->button_1touch = DEFAULT_BUTTON_1TOUCH;
 	cfg->button_2touch = DEFAULT_BUTTON_2TOUCH;
 	cfg->button_3touch = DEFAULT_BUTTON_3TOUCH;
@@ -139,6 +140,7 @@ void mconfig_configure(struct MConfig* cfg,
 	cfg->button_integrated = xf86SetBoolOption(opts, "ButtonIntegrated", DEFAULT_BUTTON_INTEGRATED);
 	cfg->button_expire = MAXVAL(xf86SetIntOption(opts, "ButtonTouchExpire", DEFAULT_BUTTON_EXPIRE), 0);
 	cfg->button_zones = xf86SetBoolOption(opts, "ButtonZonesEnable", DEFAULT_BUTTON_ZONES);
+	cfg->bottom_edge_zones = xf86SetBoolOption(opts, "BottomEdgeZonesEnable", DEFAULT_BOTTOM_EDGE_ZONES);
 	cfg->button_1touch = CLAMPVAL(xf86SetIntOption(opts, "ClickFinger1", DEFAULT_BUTTON_1TOUCH), 0, 32);
 	cfg->button_2touch = CLAMPVAL(xf86SetIntOption(opts, "ClickFinger2", DEFAULT_BUTTON_2TOUCH), 0, 32);
 	cfg->button_3touch = CLAMPVAL(xf86SetIntOption(opts, "ClickFinger3", DEFAULT_BUTTON_3TOUCH), 0, 32);

--- a/src/mtstate.c
+++ b/src/mtstate.c
@@ -237,7 +237,7 @@ static void touches_update(struct MTState* ms,
 			else
 				CLEARBIT(ms->touch[n].state, MT_PALM);
 			
-			if (ms->touch[n].y > (100 - cfg->bottom_edge)*cfg->pad_height/100) {
+			if ((ms->touch[n].y - get_cap_ymin(caps)) > (100 - cfg->bottom_edge)*cfg->pad_height/100) {
 				if (GETBIT(ms->touch[n].state, MT_NEW))
 					SETBIT(ms->touch[n].state, MT_BOTTOM_EDGE);
 			}


### PR DESCRIPTION
With these patches, xf86-input-mtrack can be used to get a clickpad to more closely emulate a traditional trackpad with separate buttons, by setting BottomEdge, BottomEdgeZonesEnable, and disabling ButtonZones.

Also, some anomalies in pad xmin and ymin offset handling are fixed.  (v2 of this series)
